### PR TITLE
Add previous and next buttons to pages

### DIFF
--- a/assets/scripts/scripts.js
+++ b/assets/scripts/scripts.js
@@ -23,6 +23,28 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(data => {
             document.getElementById('footer-placeholder').innerHTML = data;
         });
+
+    // Add event listeners to the "Previous" and "Next" buttons
+    const prevButton = document.getElementById('prev-button');
+    const nextButton = document.getElementById('next-button');
+
+    if (prevButton) {
+        prevButton.addEventListener('click', () => {
+            const prevPage = getPrevNextPageUrls().prev;
+            if (prevPage) {
+                window.location.href = prevPage;
+            }
+        });
+    }
+
+    if (nextButton) {
+        nextButton.addEventListener('click', () => {
+            const nextPage = getPrevNextPageUrls().next;
+            if (nextPage) {
+                window.location.href = nextPage;
+            }
+        });
+    }
 });
 
 function toggleTheme() {
@@ -72,3 +94,21 @@ document.addEventListener('DOMContentLoaded', () => {
     button.onclick = toggleTheme;
     document.body.appendChild(button);
 });
+
+function getPrevNextPageUrls() {
+    const pages = [
+        'investor.html',
+        'management.html',
+        'milking-stand.html',
+        'milking.html',
+        'schedule.html'
+    ];
+
+    const currentPage = window.location.pathname.split('/').pop();
+    const currentIndex = pages.indexOf(currentPage);
+
+    const prevPage = currentIndex > 0 ? pages[currentIndex - 1] : null;
+    const nextPage = currentIndex < pages.length - 1 ? pages[currentIndex + 1] : null;
+
+    return { prev: prevPage, next: nextPage };
+}

--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -191,6 +191,26 @@ header.dark {
     background-color: #FFEB3B;
 }
 
-tip-box.dark, .warning-box.dark, .success-metric.dark {
+.tip-box.dark, .warning-box.dark, .success-metric.dark {
     background-color: #FFC107;
+}
+
+.prev-next-buttons {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 20px;
+}
+
+.prev-next-buttons button {
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1em;
+}
+
+.prev-next-buttons button:hover {
+    background-color: #45a049;
 }

--- a/pages/investor.html
+++ b/pages/investor.html
@@ -84,6 +84,12 @@
             <h2 class="text-2xl font-semibold mb-6">Next Steps</h2>
             <p class="text-gray-600">How to proceed with your goat farming investment.</p>
         </section>
+
+        <!-- Previous and Next Buttons -->
+        <div class="prev-next-buttons">
+            <button id="prev-button">Previous</button>
+            <button id="next-button">Next</button>
+        </div>
     </div>
 
     <!-- Include Footer -->
@@ -95,7 +101,7 @@
     </button>
 
     <!-- JavaScript -->
-    <script src="../assets/scripts/scipts.js"></script>
+    <script src="../assets/scripts/scripts.js"></script>
 
 </body>
 </html>

--- a/pages/management.html
+++ b/pages/management.html
@@ -116,6 +116,12 @@
                 </div>
             </div>
         </section>
+
+        <!-- Previous and Next Buttons -->
+        <div class="prev-next-buttons">
+            <button id="prev-button">Previous</button>
+            <button id="next-button">Next</button>
+        </div>
     </div>
 
     <!-- Include Footer -->
@@ -127,6 +133,6 @@
     </button>
 
     <!-- JavaScript -->
-    <script src="../assets/scripts/scipts.js"></script>
+    <script src="../assets/scripts/scripts.js"></script>
 </body>
 </html>

--- a/pages/milking-stand.html
+++ b/pages/milking-stand.html
@@ -76,6 +76,12 @@
             <h2 class="text-2xl font-semibold mb-6">Placeholder Image</h2>
             <img src="assets/milking-stand.png" alt="Placeholder Milking Stand">
         </section>
+
+        <!-- Previous and Next Buttons -->
+        <div class="prev-next-buttons">
+            <button id="prev-button">Previous</button>
+            <button id="next-button">Next</button>
+        </div>
     </div>
 
     <!-- Include Footer -->
@@ -87,6 +93,6 @@
     </button>
 
     <!-- JavaScript -->
-    <script src="../assets/scripts/scipts.js"></script>
+    <script src="../assets/scripts/scripts.js"></script>
 </body>
 </html>

--- a/pages/milking.html
+++ b/pages/milking.html
@@ -162,6 +162,12 @@
         <!-- [Original Milking Technique Section remains the same] -->
         <!-- [Original Storage Section remains the same] -->
         <!-- [Original Troubleshooting Section remains the same] -->
+
+        <!-- Previous and Next Buttons -->
+        <div class="prev-next-buttons">
+            <button id="prev-button">Previous</button>
+            <button id="next-button">Next</button>
+        </div>
     </div>
 
     <!-- Include Footer -->
@@ -173,6 +179,6 @@
     </button>
 
     <!-- JavaScript -->
-    <script src="../assets/scripts/scipts.js"></script>
+    <script src="../assets/scripts/scripts.js"></script>
 </body>
 </html>

--- a/pages/schedule.html
+++ b/pages/schedule.html
@@ -109,6 +109,12 @@
                 <li><a href="../investor.html" class="text-green-600 hover:text-green-700">Investor Information</a></li>
             </ul>
         </section>
+
+        <!-- Previous and Next Buttons -->
+        <div class="prev-next-buttons">
+            <button id="prev-button">Previous</button>
+            <button id="next-button">Next</button>
+        </div>
     </div>
 
     <!-- Include Footer -->
@@ -120,6 +126,6 @@
     </button>
 
     <!-- JavaScript -->
-    <script src="../../assets/scripts/scipts.js"></script>
+    <script src="../assets/scripts/scripts.js"></script>
 </body>
 </html>

--- a/shared/footer.html
+++ b/shared/footer.html
@@ -10,5 +10,9 @@
             <span class="text-gray-300">|</span>
             <a href="/pages/investor.html" class="text-green-600 hover:text-green-700">Investor Information</a>
         </div>
+        <div class="prev-next-buttons mt-8">
+            <button id="prev-button">Previous</button>
+            <button id="next-button">Next</button>
+        </div>
     </div>
 </footer>


### PR DESCRIPTION
Add "Previous" and "Next" buttons to each page in the `pages/` directory.

* **JavaScript Functionality:**
  - Add event listeners to the "Previous" and "Next" buttons in `assets/scripts/scripts.js`.
  - Add a function to get the previous and next page URLs based on the current page.

* **CSS Styling:**
  - Add styles for the "Previous" and "Next" buttons in `assets/styles/styles.css`.

* **Footer Changes:**
  - Add "Previous" and "Next" buttons to the footer in `shared/footer.html`.

* **Page Changes:**
  - Add "Previous" and "Next" buttons to the bottom of `pages/investor.html`, `pages/management.html`, `pages/milking-stand.html`, `pages/milking.html`, and `pages/schedule.html`.
  - Fix the loading of `scripts.js` in `pages/investor.html`, `pages/management.html`, `pages/milking-stand.html`, `pages/milking.html`, and `pages/schedule.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JustAGhosT/goat-farming-guide/pull/14?shareId=3704ac3b-7a89-42b3-a903-038728e200a2).